### PR TITLE
synthetic data source

### DIFF
--- a/main_demo.py
+++ b/main_demo.py
@@ -79,3 +79,6 @@ if __name__ == "__main__":
     image = np.expand_dims(image, axis=0) # add channel dimension, which save_image expects
     save_image(image)
   image_paths = glob.glob(os.path.join(data_dir,'*.png'))
+
+  # Create a data list made out of image pairs (including pairs in a symmetric and reflexive fashion)
+  data = [{'img0':image_paths[i0], 'img1':image_paths[i1]} for i0 in range(len(image_paths)) for i1 in range(len(image_paths))]

--- a/main_demo.py
+++ b/main_demo.py
@@ -14,12 +14,45 @@ import monai
 import torch
 import numpy as np
 import matplotlib.pyplot as plt
+from typing import Sequence
 
 # the part we intend to contribute
 from vsvf import Vsvf, VsvfDualizeMomentum, VsvfIntegrateVelocity
 
 # for validation only
 import mermaid
+
+def synthesize_image(shape:Sequence[int], min_size:int, max_size:int):
+  """
+  Create a random test image.
+  It will be a binary image of a shape. The shape can be an ellipsoid or a cuboid.
+  The extents along each dimension are selected from the integers in [min_size, max_size).
+  """
+  if min_size < 1:
+    raise ValueError("min_size should be positive")
+  if max_size <= min_size:
+    raise ValueError("min_size should be < max_size")
+
+  image = np.zeros(shape)
+  start_indices = [np.random.randint(0,d-min_size) for d in shape]
+  stop_indices = [
+    np.random.randint(start_index+min_size, min(start_index+max_size,d))
+    for start_index,d in zip(start_indices,shape)
+  ]
+
+  if np.random.randint(2)==1: # make an ellipse/ellipsoid/etc
+    open_mesh_grid = np.ogrid[[slice(0,d) for d in shape]]
+    centers = [(start_index + stop_index)/2. for start_index, stop_index in zip(start_indices, stop_indices)]
+    half_extents = [(stop_index-start_index)/2. for start_index, stop_index in zip(start_indices, stop_indices)]
+    normalized_coords = [(open_mesh_grid[i]-centers[i])/half_extents[i] for i in range(len(shape))]
+    ellipsoid_mask = sum(x**2 for x in normalized_coords) <= 1.0
+    image[ellipsoid_mask]=1
+
+  else: # make a rectangle/cuboid/etc
+    image[tuple(slice(start_index, stop_index) for start_index, stop_index in zip(start_indices, stop_indices))]=1
+
+  return image
+
 
 
 if __name__ == "__main__":

--- a/main_demo.py
+++ b/main_demo.py
@@ -15,6 +15,9 @@ import torch
 import numpy as np
 import matplotlib.pyplot as plt
 from typing import Sequence
+import tempfile
+import glob
+import os
 
 # the part we intend to contribute
 from vsvf import Vsvf, VsvfDualizeMomentum, VsvfIntegrateVelocity
@@ -56,4 +59,23 @@ def synthesize_image(shape:Sequence[int], min_size:int, max_size:int):
 
 
 if __name__ == "__main__":
-  pass # main demo work will go here
+
+  # Create a temporary directory to work in
+  root_dir = tempfile.mkdtemp()
+  data_dir = os.path.join(root_dir, "synthetic_data")
+  print(f"Working in the following directory: {data_dir}")
+  save_image = monai.transforms.SaveImage(
+    output_dir=data_dir,
+    output_ext='.png',
+    scale = 255, # applies to png format only
+    separate_folder = False,
+    print_log=False
+  )
+
+  # Save a bunch of synthetic images in the temporary directory
+  number_of_images_to_generate = 300
+  for _ in range(number_of_images_to_generate):
+    image = synthesize_image((128,128), 32, 96)
+    image = np.expand_dims(image, axis=0) # add channel dimension, which save_image expects
+    save_image(image)
+  image_paths = glob.glob(os.path.join(data_dir,'*.png'))


### PR DESCRIPTION
Closes #6 

Currently there's just a function to create random synthetic images. It creates a binary image of a given shape with either an ellipsoid or a cuboid in it somewhere.

To test it:
```py
from main_demo import synthesize_image
import matplotlib.pyplot as plt
plt.imshow(synthesize_image((128,128), 32, 96))
plt.show()
```

~~Still need to make a pytorch/MONAI dataset out of it in order to complete this PR.~~
Added 
- train/validation data split
- pairing up of images into fixed and moving images for registration task
- a transform that loads images from file path, adds a channel dimension, and concatenates images into one 2-channel tensor
- creation of monai datasets that use the transform

It would be good if we can later easily swap out the synthetic data creation with another data source without having to change very much code. Let me know if there's a better approach for this purpose. 